### PR TITLE
feat: Add 30-minute timer and reset functionality - Add automatic sto…

### DIFF
--- a/cursor-auto-resume.js
+++ b/cursor-auto-resume.js
@@ -5,10 +5,31 @@
     // Track last click time to avoid multiple clicks
     let lastClickTime = 0;
     
+    // Timer variables
+    let startTime = Date.now();
+    const maxDuration = 30 * 60 * 1000; // 30 minutes in milliseconds
+    let intervalId;
+    
+    // Function to reset the timer
+    function click_reset() {
+        startTime = Date.now();
+        console.log('Cursor Auto Resume: Timer reset');
+    }
+    
+    // Make click_reset available globally
+    window.click_reset = click_reset;
+    
     // Main function that looks for and clicks the resume link
     function clickResumeLink() {
-        // Prevent clicking too frequently (3 second cooldown)
+        // Check if 30 minutes have passed
         const now = Date.now();
+        if (now - startTime > maxDuration) {
+            console.log('Cursor Auto Resume: 30 minutes elapsed, stopping auto-click');
+            clearInterval(intervalId);
+            return;
+        }
+        
+        // Prevent clicking too frequently (3 second cooldown)
         if (now - lastClickTime < 3000) return;
         
         // Find elements with rate limit text
@@ -35,9 +56,12 @@
     }
     
     // Run periodically
-    setInterval(clickResumeLink, 1000);
+    intervalId = setInterval(clickResumeLink, 1000);
     
     // Also run once immediately
     clickResumeLink();
+    
+    // Log timer info
+    console.log('Cursor Auto Resume: Will stop after 30 minutes. Call click_reset() to reset timer.');
     
 })(); 


### PR DESCRIPTION
# Add 30-minute timer and reset functionality

## Summary
This PR enhances the cursor-auto-resume script by adding automatic stopping after 30 minutes and a reset function to prevent infinite running while maintaining user control.

## What's New
- **30-minute auto-stop**: Script automatically stops clicking after 30 minutes to prevent infinite running
- **Reset function**: New `click_reset()` function allows users to restart the timer when needed
- **Global access**: Reset function is accessible via `window.click_reset` in the browser console
- **Better logging**: Enhanced user feedback with clear status messages

## Technical Changes
- Added timer variables to track script runtime
- Implemented proper interval cleanup when timer expires
- Made reset function globally accessible for easy use
- Maintained backward compatibility with existing functionality

## Use Case
This addresses the need for:
- **Preventing runaway scripts** that could run indefinitely
- **User control** over script runtime without needing to reload the page
- **Professional usage** where time-limited automation is preferred

## Usage
1. Run the script as usual in the browser console
2. Script will automatically stop after 30 minutes
3. To reset the timer: type `click_reset()` in the console
4. Script will continue for another 30 minutes

## Benefits
- Maintains all existing functionality
- Adds safety mechanism against infinite running
- Provides user control without page reload
- No breaking changes

This enhancement makes the tool more suitable for extended development sessions while maintaining respect for Cursor's service infrastructure. 